### PR TITLE
Treat *.graphcool project files as graphql files

### DIFF
--- a/syntaxes/graphql.json
+++ b/syntaxes/graphql.json
@@ -3,7 +3,8 @@
   "scopeName": "source.graphql",
   "fileTypes": [
     "graphql",
-    "gql"
+    "gql",
+    "graphcool"
   ],
   "patterns": [
     { "include": "#graphql" }


### PR DESCRIPTION
Adding support for graphcool's project file. See https://www.graph.cool/docs/reference/cli/project-files-ow2yei7mew/ for an example. I haven't tested these changes, but I believe I only need to add the *.graphcool extension somewhere in the project.