### PR TITLE
feat(syntax): support relay modern’s `graphql.experimental` tag.

### DIFF
--- a/syntaxes/graphql.js.json
+++ b/syntaxes/graphql.js.json
@@ -4,7 +4,7 @@
   "patterns": [
     {
       "name": "taggedTemplates",
-      "begin": "(Relay.QL|gql|graphql)(`)",
+      "begin": "(Relay.QL|gql|graphql(\\.experimental)?)(`)",
       "beginCaptures": {
         "1": {
           "name": "entity.name.function.tagged-template.js"


### PR DESCRIPTION
As can be seen used in for instance this example https://facebook.github.io/relay/docs/refetch-container.html