### PR TITLE
Mark graphql query string contents as language: graphql

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,10 @@
           "source.tsx"
         ],
         "scopeName": "inline.graphql",
-        "path": "./syntaxes/graphql.js.json"
+        "path": "./syntaxes/graphql.js.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.graphql": "graphql"
+        }
       }
     ],
     "snippets": [

--- a/syntaxes/graphql.js.json
+++ b/syntaxes/graphql.js.json
@@ -4,6 +4,7 @@
   "patterns": [
     {
       "name": "taggedTemplates",
+      "contentName": "meta.embedded.block.graphql",
       "begin": "(Relay\\.QL|gql|graphql(\\.experimental)?)(`)",
       "beginCaptures": {
         "1": {


### PR DESCRIPTION
Fixes #43

Ensures that the contents of graphql query string in js/ts files are marked as being the graphql language rather than js/ts