### PR TITLE
Support syntax highlighting for GraphQL inside of Ruby heredoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,24 @@ VSCode extension for GraphQL schema authoring & consumption.
     }
     ```
 
+5. Here's an example of a sample config you might use for Ruby-aware highlighting (inside `<<-GRAPHQL` heredocs):
+
+    ```
+    {
+      schema: {
+        files: "schemas/**/*.gql"
+      },
+      query: {
+        files: [
+          {
+            "match": "lib/**/*.rb",
+            "parser": ["EmbeddedQueryParser", { "startTag": "<<-GRAPHQL", "endTag": "GRAPHQL" }]
+          }
+        ]
+      }
+    }
+    ```
+
     Again, refer to [GQL](https://github.com/Mayank1791989/gql) docs for details about configuring your .gqlconfig.
 
 ## Future Plans

--- a/package.json
+++ b/package.json
@@ -104,6 +104,21 @@
         "embeddedLanguages": {
           "meta.embedded.block.graphql": "graphql"
         }
+      },
+      {
+        "language": "graphql",
+        "scopeName": "source.graphql",
+        "path": "./syntaxes/graphql.json"
+      },
+      {
+        "injectTo": [
+          "source.ruby"
+        ],
+        "scopeName": "inline.graphql",
+        "path": "./syntaxes/graphql.rb.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.graphql": "graphql"
+        }
       }
     ],
     "snippets": [

--- a/syntaxes/graphql.rb.json
+++ b/syntaxes/graphql.rb.json
@@ -1,0 +1,26 @@
+{
+  "fileTypes": ["rb"],
+  "injectionSelector": "L:source -string -comment",
+  "patterns": [
+    {
+      "name": "taggedTemplates",
+      "contentName": "meta.embedded.block.graphql",
+      "begin": "(?=(?><<[-~]('?)|(\"?)((?:[_\\w]+_|)GRAPHQL)\\b\\1))",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.ruby"
+        }
+      },
+      "end": "\\s*\\2$\\n?",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.ruby"
+        }
+      },
+      "patterns": [
+        { "include": "source.graphql" }
+      ]
+    }
+  ],
+  "scopeName": "inline.graphql"
+}


### PR DESCRIPTION
using `<<-GRAPHQL` as the delimiter.

Looks like:

<img width="386" alt="screen shot 2017-10-16 at 6 31 41 pm" src="https://user-images.githubusercontent.com/1457859/31668831-425508e8-b321-11e7-877d-b082bde7eade.png">

Vs, without this addition:

<img width="371" alt="screen shot 2017-10-17 at 9 55 35 am" src="https://user-images.githubusercontent.com/1457859/31668864-5a30bbce-b321-11e7-892e-82c942f99529.png">

Inspired by https://github.com/atom/language-ruby/pull/187 
