### PR TITLE
VS Code renamed their javascript react scope to `source.js.jsx`

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
         "injectTo": [
           "source.js",
           "source.ts",
-          "source.jsx",
+          "source.js.jsx",
           "source.tsx"
         ],
         "scopeName": "inline.graphql",

--- a/syntaxes/graphql.json
+++ b/syntaxes/graphql.json
@@ -602,7 +602,7 @@
       "patterns": [
         { "include": "source.js" },
         { "include": "source.ts" },
-        { "include": "source.jsx" },
+        { "include": "source.js.jsx" },
         { "include": "source.tsx" }
       ]
     },


### PR DESCRIPTION
It seems that VS Code has renamed their internal scope name for `javascriptreact` from `source.jsx` to `source.js.jsx`.  This broke the injection selector for this plugin.  😞 

For reference, you can see the VS Code commit history here:

https://github.com/Microsoft/vscode/blame/048592897e707b5f57cc51aea3e9e35b224fc7dd/extensions/javascript/syntaxes/JavaScriptReact.tmLanguage.json