### PR TITLE
Add new keyword to enable GraphQL syntax highlighting

### DIFF
--- a/syntaxes/graphql.js.json
+++ b/syntaxes/graphql.js.json
@@ -23,6 +23,28 @@
       "patterns": [
         { "include": "source.graphql" }
       ]
+    },
+    {
+      "name": "taggedTemplates",
+      "contentName": "meta.embedded.block.graphql",
+      "begin": "(`)(#graphql)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.string.template.begin.js"
+        },
+        "2": {
+          "name": "comment.line.graphql.js"
+        }
+      },
+      "end": "`",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.template.end.js"
+        }
+      },
+      "patterns": [
+        { "include": "source.graphql" }
+      ]
     }
   ],
   "scopeName": "inline.graphql"


### PR DESCRIPTION
**What**
This pull-requests adds a new pattern to recognise GraphQL in tagged templates in javascript files.

**Why**
The reason why I propose this change is that there are times when you write GraphQL without a `gql` or `Relay.GL` functions to parse them, but still want syntax highlighting.

**How**
My proposition is to recognise the tagged template string as GraphQL if it starts with the comment `#graphql`.

**Example**
<img width="668" alt="screen shot 2017-11-28 at 18 36 19" src="https://user-images.githubusercontent.com/1495211/33334722-1e618892-d46b-11e7-80b5-e40edb4dfebd.png">
