### PR TITLE
Add support for Apollo's extend keyword

### DIFF
--- a/syntaxes/graphql.json
+++ b/syntaxes/graphql.json
@@ -63,7 +63,7 @@
     },
     "graphql-type-interface": {
       "name": "meta.type.interface.graphql",
-      "begin": "\\s*\\b(?:(extends)?\\b\\s*\\b(type)|(interface)|(input))\\b\\s*([_A-Za-z][_0-9A-Za-z]*)?",
+      "begin": "\\s*\\b(?:(extends?)?\\b\\s*\\b(type)|(interface)|(input))\\b\\s*([_A-Za-z][_0-9A-Za-z]*)?",
       "end": "(?<=})",
       "captures": {
         "1": { "name": "keyword.type.graphql"},


### PR DESCRIPTION
Fixes #72. This is a pretty simple change to support `extend` in addition to `extends`. I tested it and it works, though it's pretty simple so hopefully that's self-evident.