### PR TITLE
Add support for empty types

### DIFF
--- a/syntaxes/graphql.json
+++ b/syntaxes/graphql.json
@@ -65,6 +65,7 @@
       "name": "meta.type.interface.graphql",
       "begin": "\\s*\\b(?:(extends)?\\b\\s*\\b(type)|(interface)|(input))\\b\\s*([_A-Za-z][_0-9A-Za-z]*)?",
       "end": "(?=.)",
+      "applyEndPatternLast": 1,
       "captures": {
         "1": { "name": "keyword.type.graphql"},
         "2": { "name": "keyword.type.graphql"},

--- a/syntaxes/graphql.json
+++ b/syntaxes/graphql.json
@@ -64,7 +64,7 @@
     "graphql-type-interface": {
       "name": "meta.type.interface.graphql",
       "begin": "\\s*\\b(?:(extends)?\\b\\s*\\b(type)|(interface)|(input))\\b\\s*([_A-Za-z][_0-9A-Za-z]*)?",
-      "end": "(?<=})",
+      "end": "(?=.)",
       "captures": {
         "1": { "name": "keyword.type.graphql"},
         "2": { "name": "keyword.type.graphql"},
@@ -94,8 +94,12 @@
         { "include": "#graphql-description-docstring" },
         { "include": "#graphql-directive" },
         { "include": "#graphql-type-object" },
-        { "include": "#literal-quasi-embedded" }
+        { "include": "#literal-quasi-embedded" },
+        { "include": "#graphql-ignore-spaces" }
       ]
+    },
+    "graphql-ignore-spaces": {
+      "match": "\\s*"
     },
     "graphql-type-object": {
       "name": "meta.type.object.graphql",


### PR DESCRIPTION
Fixes #71. This is based on the same feature in [the Atom language-babel extension.](https://github.com/gandm/language-babel/commit/9f8fa420aa7dde89fa4f74ffe02f4516cec55047). I have tested this on some of my own GraphQL queries and haven't seen a few problems with it. It causes a problem with the `implements` clause in types, where the implemented interface doesn't highlight correctly. Any ideas for how to fix this?