### PR TITLE
Add support for template literals in .vue files

### DIFF
--- a/syntaxes/graphql.js.json
+++ b/syntaxes/graphql.js.json
@@ -1,5 +1,5 @@
 {
-  "fileTypes": ["js", "jsx", "ts", "tsx"],
+  "fileTypes": ["js", "jsx", "ts", "tsx", "vue"],
   "injectionSelector": "L:source -string -comment",
   "patterns": [
     {


### PR DESCRIPTION
Fixes #84. Simply add `vue` files to the JavaScript syntax that enables the graphql template literal syntax highlighting.