### PR TITLE
Add syntax highlight for markdown embedded

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,16 @@
         ],
         "scopeName": "text.gherkin.feature.graphql",
         "path": "./syntaxes/graphql.feature.json"
+      },
+      {
+        "scopeName": "markdown.graphql.codeblock",
+        "path": "./syntaxes/graphql.markdown.codeblock.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.graphql": "GraphQL"
+        }
       }
     ],
     "snippets": [

--- a/syntaxes/graphql.markdown.codeblock.json
+++ b/syntaxes/graphql.markdown.codeblock.json
@@ -1,0 +1,28 @@
+{
+  "fileTypes": [],
+  "injectionSelector": "L:markup.fenced_code.block.markdown",
+  "patterns": [
+    {
+      "include": "#graphql-code-block"
+    }
+  ],
+  "repository": {
+    "graphql-code-block": {
+      "begin": "(graphql|GraphQL)(\\s+[^`~]*)?$",
+      "end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
+      "patterns": [
+        {
+          "begin": "(^|\\G)(\\s*)(.*)",
+          "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+          "contentName": "meta.embedded.block.graphql",
+          "patterns": [
+            {
+              "include": "source.graphql"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "scopeName": "markdown.graphql.codeblock"
+}


### PR DESCRIPTION
Hi this PR add syntax highlight for markdown embedded `graphql` block.
The regex could be improved to match better, and I have no idea how to write ignorecase in vscode pattern. 