### PR TITLE
feat(syntax): add support for reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ VSCode extension for GraphQL schema authoring & consumption.
   + Vue
   + Ruby
   + Cucumber
+  + ReasonML/OCaml
   + (Submit a PR to support your language!)
 
 * **Snippets**: Some commonly used snippets are provided which help while writing mutations and queries, such as defining types, interfaces and input types.

--- a/package.json
+++ b/package.json
@@ -109,6 +109,17 @@
       },
       {
         "injectTo": [
+          "source.reason",
+          "source.ocaml"
+        ],
+        "scopeName": "inline.graphql.re",
+        "path": "./syntaxes/graphql.re.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.graphql": "graphql"
+        }
+      },
+      {
+        "injectTo": [
           "source.ruby"
         ],
         "scopeName": "inline.graphql.rb",

--- a/syntaxes/graphql.re.json
+++ b/syntaxes/graphql.re.json
@@ -1,0 +1,20 @@
+{
+  "fileTypes": [
+    "re",
+    "ml"
+  ],
+  "injectionSelector": "L:source -string -comment",
+  "patterns": [
+    {
+      "contentName": "meta.embedded.block.graphql",
+      "begin": "({)(gql)(\\|)",
+      "end": "(\\|)(\\2)(})",
+      "patterns": [
+        {
+          "include": "source.graphql"
+        }
+      ]
+    }
+  ],
+  "scopeName": "inline.graphql.re"
+}


### PR DESCRIPTION
This adds syntax highlighting when using the `gql` for string interpolation example:
```ocaml
{gql|
  type Thing {
    id: ID!
    name: String!
    description: String!
 }
|gql}
```
But it doesn't try to highlight with the more standard `j`.