### PR TITLE
feat(syntax): add support for graphql_ppx in reason

### DIFF
--- a/syntaxes/graphql.re.json
+++ b/syntaxes/graphql.re.json
@@ -1,8 +1,5 @@
 {
-  "fileTypes": [
-    "re",
-    "ml"
-  ],
+  "fileTypes": ["re", "ml"],
   "injectionSelector": "L:source -string -comment",
   "patterns": [
     {
@@ -14,6 +11,24 @@
           "include": "source.graphql"
         }
       ]
+    },
+    {
+      "contentName": "meta.embedded.block.graphql",
+      "begin": "(\\[%graphql)s*$",
+      "end": "(?<=])",
+      "patterns": [
+        {
+          "begin": "^\\s*({\\|)$",
+          "end": "^\\s*(\\|})",
+          "patterns": [{ "include": "source.graphql" }]
+        }
+      ]
+    },
+    {
+      "contentName": "meta.embedded.block.graphql",
+      "begin": "(\\[%graphql {\\|)",
+      "end": "(\\|}( )?])",
+      "patterns": [{ "include": "source.graphql" }]
     }
   ],
   "scopeName": "inline.graphql.re"


### PR DESCRIPTION
Adds support for syntax highlighting when using [graphql_ppx](https://github.com/mhallin/graphql_ppx).

I didn't know how to add them in the same pattern. The first is how refmt formats (at least my code gets formatted that way) and the second is how the examples are formatted.