### PR TITLE
[docs] Add doc to pull remote schema & parse gql template literal

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,37 @@ VSCode extension for GraphQL schema authoring & consumption.
 
     Again, refer to [GQL](https://github.com/Mayank1791989/gql) docs for details about configuring your .gqlconfig.
 
+
+## Using remote schemas
+
+If you are using a schema that is not in your client's project, you'll need to download it so it's available for `@playlyfe/gql`. 
+Indeed you need to reference these schemas in your `.gqlconfig`.
+
+One way to do this is to use the [graphql-cli](https://github.com/graphql-cli/graphql-cli) commands:
+
+```
+// package.json
+{
+  ...
+  "scripts": {
+    "gql:fetch-schema": "graphql get-schema --project prod",
+  }
+  ...
+}
+```
+
+You also need a `.graphqlconfig.yml` configuration file so that graphql-cli knows what is `--project prod` in your command:
+
+```
+// .graphqlconfig.yml
+projects:
+  prod:
+    schemaPath: schema/schema.graphql
+    extensions:
+      endpoints:
+        default: https://prod.my-graphql-api.com/graphql
+```
+
 ## Future Plans
 * Tests: Figure out tests.
 

--- a/README.md
+++ b/README.md
@@ -74,9 +74,15 @@ VSCode extension for GraphQL schema authoring & consumption.
       },
       query: {
         files: [ /* define file paths which you'd like the gql parser to watch and give autocomplete suggestions for */
+          files: [
+            {
+              match: ['src/**/*.ts', 'src/**/*.tsx'], // match multiple extensions
+              parser: ['EmbeddedQueryParser', { startTag: 'gql`', endTag: '`' }], // parse any query inside gql template literal
+            },
+          ],
           {
             match: 'ui/src/**/*.js', // for js
-            parser: ['EmbeddedQueryParser', { startTag: 'Relay\\.QL`', endTag: '`' }],
+            parser: ['EmbeddedQueryParser', { startTag: 'Relay\\.QL`', endTag: '`' }], // match Relay syntax
             isRelay: true,
           },
           {

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ VSCode extension for GraphQL schema authoring & consumption.
       },
       query: {
         files: [ /* define file paths which you'd like the gql parser to watch and give autocomplete suggestions for */
-          files: [
             {
               match: ['src/**/*.ts', 'src/**/*.tsx'], // match multiple extensions
               parser: ['EmbeddedQueryParser', { startTag: 'gql`', endTag: '`' }], // parse any query inside gql template literal
@@ -82,7 +81,7 @@ VSCode extension for GraphQL schema authoring & consumption.
           ],
           {
             match: 'ui/src/**/*.js', // for js
-            parser: ['EmbeddedQueryParser', { startTag: 'Relay\\.QL`', endTag: '`' }], // match Relay syntax
+            parser: ['EmbeddedQueryParser', { startTag: 'Relay\\.QL`', endTag: '`' }], // parse Relay syntax
             isRelay: true,
           },
           {

--- a/README.md
+++ b/README.md
@@ -135,6 +135,13 @@ projects:
         default: https://prod.my-graphql-api.com/graphql
 ```
 
+You will need to download this schema each time there is a new update in your api:
+
+```
+// download schema
+yarn gql:fetch-schema
+```
+
 ## Future Plans
 * Tests: Figure out tests.
 


### PR DESCRIPTION
* Add an example to match multiple file extensions
* Add an example to parse `gql` template literal
```
gql`
  query { ... }
`
```
* Add a section to explain how to pull remove schema that is required for this plugin

This is to fix https://github.com/kumarharsh/graphql-for-vscode/issues/162