### PR TITLE
feat(syntax): follow standard TM conventions for variable-name highlighting

### DIFF
--- a/syntaxes/graphql.json
+++ b/syntaxes/graphql.json
@@ -128,7 +128,7 @@
       "begin": "\\s*([_A-Za-z][_0-9A-Za-z]*)(?=\\s*\\(|:)",
       "end": "(?=\\s*(([_A-Za-z][_0-9A-Za-z]*)\\s*(\\(|:)|(})))|\\s*(,)",
       "beginCaptures": {
-        "1": { "name": "variable.graphql" }
+        "1": { "name": "variable.other.graphql" }
       },
       "endCaptures": {
         "5": { "name": "punctuation.comma.graphql" }
@@ -396,7 +396,7 @@
         {
           "match": "\\s*([_A-Za-z][_0-9A-Za-z]*)",
           "captures": {
-            "1": { "name": "variable.graphql" }
+            "1": { "name": "variable.other.graphql.field" }
           }
         },
         { "include": "#graphql-arguments" },
@@ -481,7 +481,7 @@
     "graphql-variable-name": {
       "match": "\\s*(\\$[_A-Za-z][_0-9A-Za-z]*)",
       "captures": {
-        "1": { "name": "variable.graphql" }
+        "1": { "name": "variable.other.graphql" }
       }
     },
     "graphql-float-value": {


### PR DESCRIPTION
Follows a more-established [convention](https://macromates.com/manual/en/language_grammars#naming_conventions) for identifying variable names in GQL files, allowing these tokens to be highlighted by most themes (including the vast majority of themes that aren't specifically targeted at this grammar).

Any themes that treat `variable.graphql` differently from `variable.other` would need to be updated, although I haven't seen any themes that actually do this.  

Here's a quick example of how highlighting changes when using the `Solarized Dark` theme:

### Before
![Screen Shot 2019-09-03 at 3 17 54 PM](https://user-images.githubusercontent.com/1102667/64201995-0a813b80-ce5e-11e9-9f8a-b72f88fdc71f.png)

### After
![Screen Shot 2019-09-03 at 3 17 30 PM](https://user-images.githubusercontent.com/1102667/64202028-1a991b00-ce5e-11e9-8a15-9636c94894c6.png)

---

One question I have is whether or not it makes more sense to go a step further and redefine field selections (`result1` and `result2` in the above example) as `meta.object.member` or `meta.object-literal.key`) to more-closely resemble the semantics of a JS object literal.  