### PR TITLE
Add directive highlighting for type system directives

### DIFF
--- a/syntaxes/graphql.json
+++ b/syntaxes/graphql.json
@@ -137,6 +137,7 @@
         { "include": "#graphql-comment" },
         { "include": "#graphql-description-docstring" },
         { "include": "#graphql-description-singleline" },
+        { "include": "#graphql-directive" },
         { "include": "#graphql-variable-definitions" },
         { "include": "#graphql-type-object" },
         { "include": "#graphql-colon"},
@@ -255,6 +256,7 @@
         { "include": "#graphql-comment" },
         { "include": "#graphql-description-docstring" },
         { "include": "#graphql-description-singleline" },
+        { "include": "#graphql-directive" },
         { "include": "#graphql-colon" },
         { "include": "#graphql-input-types"},
         { "include": "#graphql-variable-assignment"},
@@ -471,6 +473,7 @@
             { "include": "#graphql-comment" },
             { "include": "#graphql-description-docstring" },
             { "include": "#graphql-description-singleline" },
+            { "include": "#graphql-directive" },
             { "include": "#graphql-value" },
             { "include": "#graphql-skip-newlines" }
           ]
@@ -555,10 +558,15 @@
             { "include": "#graphql-comment" },
             { "include": "#graphql-description-docstring" },
             { "include": "#graphql-description-singleline" },
+            { "include": "#graphql-directive" },
             { "include": "#graphql-enum-value" },
             { "include": "#literal-quasi-embedded" }
           ]
-        }
+        },
+        { "include": "#graphql-comment" },
+        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-description-singleline" },
+        { "include": "#graphql-directive" }
       ]
     },
     "graphql-enum-value": {


### PR DESCRIPTION
GraphQL directives can be added to many places:
https://spec.graphql.org/draft/#sec-Type-System.Directives

Currently not all places listed in the spec are supported for syntax highlighting. Especially many type system directive locations are missing. This pull request adds the missing places to the grammar, so that directives are syntax highlighted on all possible places.